### PR TITLE
Generate struct definitions in base ir while lowering programs into base

### DIFF
--- a/core/main.rs
+++ b/core/main.rs
@@ -104,6 +104,15 @@ mod test {
     }
 
     #[test]
+    fn captures() {
+        codegen_program(
+            r#"
+            fn main(x: Int) -> Int = ([x: Int](y: Int) -> Int = x)(5)
+        "#,
+        )
+    }
+
+    #[test]
     fn tuple_construction() {
         codegen_program(
             r#"

--- a/ir/src/base.rs
+++ b/ir/src/base.rs
@@ -5,6 +5,7 @@ use std::fmt;
 #[derive(Clone)]
 pub struct Program {
     pub enums: Vec<Enum>,
+    pub structs: Vec<Struct>,
     pub functions: Vec<Function>,
 }
 
@@ -15,6 +16,12 @@ pub struct Function {
     pub typ: Type,
     pub body: Vec<Stmt>,
     pub result: Identifier,
+}
+
+#[derive(Clone)]
+pub struct Struct {
+    pub name: Identifier,
+    pub fields: Vec<Type>,
 }
 
 #[derive(Clone)]
@@ -84,6 +91,9 @@ impl fmt::Debug for Program {
         for enum_def in &self.enums {
             enum_def.fmt(f)?;
         }
+        for struct_def in &self.structs {
+            struct_def.fmt(f)?;
+        }
         for func in &self.functions {
             func.fmt(f)?;
         }
@@ -144,6 +154,14 @@ impl fmt::Debug for Function {
         }
         indent(1, f)?;
         write!(f, "return {:?};\n}}\n", self.result)
+    }
+}
+
+impl fmt::Debug for Struct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "struct {:?} {{", self.name)?;
+        comma_list(f, &self.fields)?;
+        write!(f, "}}\n")
     }
 }
 

--- a/lambda-set/src/lower.rs
+++ b/lambda-set/src/lower.rs
@@ -201,7 +201,11 @@ pub(crate) fn lower_program(to_lower: &Program, lower: &mut Lower) -> base::Prog
         enums.push(lower_enum(enum_def, lower));
     }
 
-    base::Program { enums, functions }
+    base::Program {
+        enums,
+        functions,
+        structs: Vec::new(),
+    }
 }
 
 fn lower_enum(to_lower: &Enum, lower: &mut Lower) -> base::Enum {


### PR DESCRIPTION
The lowering of closures and anonymous functions requires the compiler to generate struct definitions. These definitions are now explicitly stored in base.