### PR TITLE
Implement codegen for the base ir

### DIFF
--- a/codegen/src/generator.rs
+++ b/codegen/src/generator.rs
@@ -15,7 +15,7 @@ pub enum Kind {
 pub struct Definition {
     kind: Kind,
     name: String,
-    fields: Vec<String>,
+    fields: Option<Vec<String>>,
 }
 
 #[derive(Debug)]
@@ -38,8 +38,19 @@ pub enum Statement {
 }
 
 impl Program {
+    pub fn forward_definition(&mut self, kind: Kind, name: String) {
+        self.defs.push(Definition {
+            kind,
+            name,
+            fields: None,
+        })
+    }
     pub fn definition(&mut self, kind: Kind, name: String, fields: Vec<String>) {
-        self.defs.push(Definition { kind, name, fields });
+        self.defs.push(Definition {
+            kind,
+            name,
+            fields: Some(fields),
+        });
     }
 
     pub fn function(&mut self, function: Function) {
@@ -66,14 +77,19 @@ impl Definition {
         let mut output = String::from(self.kind.keyword());
         output.push(' ');
         output.push_str(&self.name);
-        output.push_str(" {\n");
-        for field in self.fields {
-            output.push_str(&ind(1));
-            output.push_str(&field);
-            output.push_str(self.kind.delimeter());
-            output.push('\n')
+
+        if let Some(fields) = self.fields {
+            output.push_str(" {\n");
+            for field in fields {
+                output.push_str(&ind(1));
+                output.push_str(&field);
+                output.push_str(self.kind.delimeter());
+                output.push('\n')
+            }
+            output.push('}');
         }
-        output.push_str("};\n");
+        output.push_str(";\n");
+
         output
     }
 }
@@ -88,6 +104,7 @@ impl Function {
         }
     }
 
+    #[allow(dead_code, clippy::self_named_constructors)]
     pub fn function(
         result: String,
         name: String,

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,225 +1,63 @@
-use std::collections::HashMap;
-
 use generator::{self as gen, Kind};
-use ir::parsed::{Enum, Expr, Function, Identifier, Program, Type};
+use ir::base::{Enum, Program, Struct, Type};
 
 mod generator;
 
-struct Env {
-    pub prog: gen::Program,
-    names: usize,
-    tuples: HashMap<Vec<Type>, String>,
-    enums: HashMap<Identifier, Enum>,
+pub fn gen_program(program: &Program) -> gen::Program {
+    let mut builder = gen::Program::default();
+
+    for enum_def in &program.enums {
+        gen_enum(enum_def, &mut builder);
+    }
+
+    for struct_def in &program.structs {
+        gen_struct(struct_def, &mut builder);
+    }
+
+    builder
 }
 
-impl Env {
-    pub fn fresh_name(&mut self, prefix: &str) -> String {
-        let id = self.names;
-        self.names += 1;
-        format!("{}_{}", prefix, id)
-    }
-
-    pub fn tuple_name(&mut self, tuple: &[Type]) -> String {
-        if let Some(name) = self.tuples.get(tuple) {
-            name.clone()
-        } else {
-            let name = self.fresh_name("tuple");
-
-            tuple_definition(name.clone(), tuple, self);
-
-            self.tuples.insert(tuple.to_vec(), name.clone());
-
-            name
-        }
-    }
-}
-
-pub fn program(prog: &Program) -> String {
-    generate_program(prog).generate()
-}
-
-fn generate_program(prog: &Program) -> gen::Program {
-    let builder = gen::Program::default();
-    let mut env = Env {
-        prog: builder,
-        names: 0,
-        tuples: HashMap::new(),
-        enums: prog.enums.clone(),
-    };
-    for def in prog.enums.values() {
-        enum_definition(def, &mut env);
-    }
-
-    for func in &prog.functions {
-        let def = forward_function(func, &mut env);
-        env.prog.function(def);
-    }
-
-    for func in &prog.functions {
-        function(func, &mut env);
-    }
-
-    println!("{:#?}", env.prog);
-
-    env.prog
-}
-
-fn tuple_definition(name: String, tuple: &[Type], env: &mut Env) {
-    let fields = tuple
+fn gen_struct(struct_def: &Struct, builder: &mut gen::Program) {
+    let fields = struct_def
+        .fields
         .iter()
         .enumerate()
-        .map(|(i, elem)| format!("{} field{}", typ_to_string(elem, env), i))
+        .map(|(i, field)| format!("{} field{}", gen_type(field), i))
         .collect();
-    env.prog.definition(Kind::Struct, name, fields);
+    builder.definition(Kind::Struct, struct_def.name.name.clone(), fields);
 }
 
-fn enum_definition(def: &Enum, env: &mut Env) {
-    let tag_cases = def
+fn gen_enum(enum_def: &Enum, builder: &mut gen::Program) {
+    let (tag_fields, union_fields) = enum_def
         .cases
         .iter()
-        .map(|(case, _)| format!("{}_{}", def.name.name, case.name))
-        .collect();
-    env.prog
-        .definition(Kind::Enum, format!("{}_tag", def.name.name), tag_cases);
-
-    let union_fields = def
-        .cases
-        .iter()
-        .map(|(case, typ)| format!("{} {}", typ_to_string(typ, env), case.name))
-        .collect();
-    env.prog.definition(
+        .map(|(case, typ)| {
+            (
+                format!("{}_{}", enum_def.name.name, case.name),
+                format!("{} {}", gen_type(typ), case.name),
+            )
+        })
+        .unzip();
+    let struct_fields = vec![
+        format!("enum {}_tag tag", enum_def.name.name),
+        format!("union {}_value value", enum_def.name.name),
+    ];
+    builder.definition(
+        Kind::Enum,
+        format!("{}_tag", enum_def.name.name),
+        tag_fields,
+    );
+    builder.definition(
         Kind::Union,
-        format!("{}_value", def.name.name),
+        format!("{}_value", enum_def.name.name),
         union_fields,
     );
-
-    env.prog.definition(
-        Kind::Struct,
-        def.name.name.clone(),
-        vec![
-            format!("enum {}_tag tag", def.name.name),
-            format!("union {}_value value", def.name.name),
-        ],
-    );
+    builder.definition(Kind::Struct, enum_def.name.name.clone(), struct_fields);
 }
 
-fn forward_function(func: &Function, env: &mut Env) -> gen::Function {
-    let args = func
-        .arguments
-        .iter()
-        .map(|arg| (typ_to_string(&arg.typ, env), arg.name.name.clone()))
-        .collect();
-    gen::Function::forward(
-        typ_to_string(&func.result, env),
-        func.name.name.clone(),
-        args,
-    )
-}
-
-fn function(func: &Function, env: &mut Env) {
-    let mut output = forward_function(func, env);
-    let mut block = gen::Block::default();
-
-    let result = expr(&func.body, &mut block, env);
-    block.line(format!("return {}", result));
-
-    output.body = Some(block);
-    env.prog.function(output);
-}
-
-fn expr(to_gen: &Expr, block: &mut gen::Block, env: &mut Env) -> String {
-    match to_gen {
-        Expr::Integer(int) => int.to_string(),
-        Expr::Variable { name, .. } => name.name.clone(),
-        Expr::FunctionCall {
-            function,
-            arguments,
-            set,
-        } => {
-            todo!()
-        }
-        Expr::Function { .. } => unreachable!(),
-        Expr::Tuple(elems) => {
-            let typ = elems.iter().map(|e| e.typ()).collect::<Vec<_>>();
-            let name = env.tuple_name(&typ);
-
-            let mut output = format!("(struct {}) {{", name);
-
-            let mut first = true;
-            for elem in elems {
-                if first {
-                    first = false;
-                } else {
-                    output.push_str(",");
-                }
-                output.push(' ');
-                output.push_str(&expr(elem, block, env));
-            }
-            output.push_str(" }");
-            output
-        }
-        Expr::TupleAccess(tuple, field) => {
-            format!("({}).field{}", expr(&tuple, block, env), field)
-        }
-        Expr::Enum { typ, tag, argument } => {
-            format!(
-                "(struct {}) {{ {}_{}, {{ .{} = {} }} }}",
-                typ.name,
-                typ.name,
-                tag.name,
-                tag.name,
-                expr(&argument, block, env)
-            )
-        }
-        Expr::Match { head, cases } => {
-            let Type::Constructor(head_typ) = head.typ() else {
-                unreachable!()
-            };
-            let enum_def = env.enums[&head_typ].clone();
-            let case_typ = cases[0].body.typ();
-            let result = env.fresh_name("var");
-            block.line(format!("{} {result}", typ_to_string(&case_typ, env)));
-
-            let head_name = env.fresh_name("var");
-            let head_expr = expr(head, block, env);
-            block.line(format!(
-                "struct {} {head_name} = {head_expr}",
-                head_typ.name
-            ));
-
-            let mut switch = gen::Block::default();
-
-            for case in cases {
-                let mut local = gen::Block::default();
-                let binding_typ = enum_def.variant_type(&case.variant);
-                let binding_typ_name = typ_to_string(binding_typ, env);
-                local.line(format!(
-                    "{binding_typ_name} {} = ({head_name}).value.{}",
-                    case.binding.name, case.variant.name
-                ));
-                let expr_name = expr(&case.body, &mut local, env);
-                local.line(format!("{result} = {expr_name}",));
-                local.line(String::from("break"));
-                switch.block(
-                    format!("case {}_{}:", head_typ.name, case.variant.name),
-                    local,
-                );
-            }
-            block.block(format!("switch (({head_name}).tag)"), switch);
-            result
-        }
-    }
-}
-
-fn typ_to_string(typ: &Type, env: &mut Env) -> String {
+fn gen_type(typ: &Type) -> String {
     match typ {
-        Type::Integer => String::from("int"),
-        Type::Variable(var) => panic!("codegen with unresolved generic {:?}", var),
-        Type::Function(..) => unreachable!(),
-        Type::Tuple(elems) => {
-            let name = env.tuple_name(elems);
-            format!("struct {}", name)
-        }
         Type::Constructor(name) => format!("struct {}", name.name),
+        Type::Integer => String::from("int"),
     }
 }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,5 +1,5 @@
 use generator::{self as gen, Kind};
-use ir::base::{Enum, Program, Struct, Type};
+use ir::base::{Enum, Function, Program, Struct, Type};
 
 mod generator;
 
@@ -22,7 +22,24 @@ pub fn gen_program(program: &Program) -> gen::Program {
         gen_struct(struct_def, &mut builder);
     }
 
+    for func in &program.functions {
+        gen_foward_function(func, &mut builder);
+    }
+
     builder
+}
+
+fn gen_foward_function(func: &Function, builder: &mut gen::Program) {
+    let arguments = func
+        .arguments
+        .iter()
+        .map(|arg| (gen_type(&arg.typ), arg.name.name.clone()))
+        .collect();
+    builder.function(gen::Function::forward(
+        gen_type(&func.typ),
+        func.name.name.clone(),
+        arguments,
+    ))
 }
 
 fn gen_struct(struct_def: &Struct, builder: &mut gen::Program) {

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -7,6 +7,14 @@ pub fn gen_program(program: &Program) -> gen::Program {
     let mut builder = gen::Program::default();
 
     for enum_def in &program.enums {
+        builder.forward_definition(Kind::Struct, enum_def.name.name.clone());
+    }
+
+    for struct_def in &program.structs {
+        builder.forward_definition(Kind::Struct, struct_def.name.name.clone());
+    }
+
+    for enum_def in &program.enums {
         gen_enum(enum_def, &mut builder);
     }
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -53,7 +53,25 @@ fn gen_stmt(stmt: &Stmt, block: &mut gen::Block) {
             block.line(format!("{} {} = {}", gen_type(typ), name.name, expr_format));
         }
         Stmt::Match { head, cases } => {
-            todo!()
+            let mut case_block = gen::Block::default();
+            for case in cases {
+                let mut inner_block = gen::Block::default();
+                inner_block.line(format!(
+                    "{} {} = {}.value.{}",
+                    gen_type(todo!()),
+                    case.binding.name,
+                    head.name,
+                    case.variant.name
+                ));
+                for stmt in &case.body {
+                    gen_stmt(&stmt, &mut inner_block);
+                }
+                case_block.block(
+                    format!("case {}_{}:", todo!(), case.variant.name),
+                    inner_block,
+                );
+            }
+            block.block(format!("switch ({})", head.name), case_block);
         }
     }
 }

--- a/core/main.rs
+++ b/core/main.rs
@@ -8,7 +8,7 @@ fn main() {
     let mut text = String::new();
     for line in stdin.lock().lines() {
         let line = line.unwrap();
-        if line == "" {
+        if line.is_empty() {
             let parsed = match parse_program(&text) {
                 Ok(p) => p,
                 Err(errors) => {
@@ -24,10 +24,7 @@ fn main() {
             println!("lowered program");
             println!("{:?}", base);
             println!("printed program");
-            /*
-            let gen = codegen::program(&flat);
-            println!("{}", gen);
-            */
+
             text.clear();
         }
         text.push_str(&line);
@@ -38,7 +35,7 @@ fn main() {
 fn parse_error(text: &str, error: Simple<char>) {
     use ariadne::*;
     Report::build(ReportKind::Error, error.span())
-        .with_message(format!("Parse error"))
+        .with_message("Parse error")
         .with_note(format!(
             "Expected one of {:?}",
             error.expected().collect::<Vec<_>>()
@@ -53,16 +50,16 @@ fn parse_error(text: &str, error: Simple<char>) {
         .unwrap();
 }
 
-fn codegen_program(program: &str) {
-    let parsed = parse_program(&program).unwrap();
-    let mut flat = flatten::program(parsed);
-    let base = lambda_set::program(&mut flat);
-    println!("{:?}", base)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn codegen_program(program: &str) {
+        let parsed = parse_program(&program).unwrap();
+        let mut flat = flatten::program(parsed);
+        let base = lambda_set::program(&mut flat);
+        println!("{:?}", base)
+    }
 
     #[test]
     fn trivial() {

--- a/core/main.rs
+++ b/core/main.rs
@@ -1,4 +1,5 @@
 use chumsky::error::Simple;
+use codegen::gen_program;
 use parser::parse_program;
 
 use std::io::{self, BufRead};
@@ -19,11 +20,10 @@ fn main() {
                 }
             };
             let mut flat = flatten::program(parsed);
-            println!("flattened program");
             let base = lambda_set::program(&mut flat);
-            println!("lowered program");
             println!("{:?}", base);
-            println!("printed program");
+
+            println!("{}", gen_program(&base).generate());
 
             text.clear();
         }

--- a/ir/src/base.rs
+++ b/ir/src/base.rs
@@ -148,12 +148,12 @@ impl fmt::Debug for Function {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "fn {:?}(", self.name)?;
         comma_list(f, &self.arguments)?;
-        write!(f, ") -> {:?} {{\n", self.typ)?;
+        writeln!(f, ") -> {:?} {{", self.typ)?;
         for stmt in &self.body {
             stmt.fmt(1, f)?;
         }
         indent(1, f)?;
-        write!(f, "return {:?};\n}}\n", self.result)
+        writeln!(f, "return {:?};\n}}", self.result)
     }
 }
 
@@ -161,7 +161,7 @@ impl fmt::Debug for Struct {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "struct {:?} {{", self.name)?;
         comma_list(f, &self.fields)?;
-        write!(f, "}}\n")
+        writeln!(f, "}}")
     }
 }
 
@@ -174,7 +174,7 @@ impl fmt::Debug for Enum {
                 .iter()
                 .map(|(name, typ)| format!("{:?}({:?})", name, typ)),
         )?;
-        write!(f, "}}\n")
+        writeln!(f, "}}")
     }
 }
 
@@ -189,20 +189,20 @@ impl Stmt {
         indent(ind, f)?;
         match self {
             Stmt::Let { name, typ, value } => {
-                write!(f, "let {:?}: {:?} = {:?};\n", name, typ, value)
+                writeln!(f, "let {:?}: {:?} = {:?};", name, typ, value)
             }
             Stmt::Match { head, cases } => {
-                write!(f, "match {:?} {{\n", head)?;
+                writeln!(f, "match {:?} {{", head)?;
                 for case in cases {
                     indent(ind + 1, f)?;
-                    write!(f, "{:?}({:?}) => {{\n", case.variant, case.binding)?;
+                    writeln!(f, "{:?}({:?}) => {{", case.variant, case.binding)?;
                     for stmt in &case.body {
                         stmt.fmt(ind + 2, f)?;
                     }
                     indent(ind + 1, f)?;
-                    write!(f, "}}\n")?;
+                    writeln!(f, "}}")?;
                 }
-                write!(f, "}}\n")
+                writeln!(f, "}}")
             }
         }
     }

--- a/lambda-set/src/lib.rs
+++ b/lambda-set/src/lib.rs
@@ -1,10 +1,5 @@
-use std::{cell::RefCell, rc::Rc};
-
 use im::HashMap;
-use ir::{
-    base,
-    parsed::{Argument, Enum, Expr, Function, Identifier, Program, Type},
-};
+use ir::{base, parsed::Program};
 use lower::{lower_program, Lower};
 use patch::{patch_function, Lambda, Patcher};
 use unify::infer_function;

--- a/lambda-set/src/lower.rs
+++ b/lambda-set/src/lower.rs
@@ -1,9 +1,7 @@
-use std::{cell::RefCell, rc::Rc};
-
-use crate::{patch::Lambda, union_find::UnionFind};
+use crate::patch::Lambda;
 use im::{HashMap, HashSet};
 use ir::base::{self, Stmt};
-use ir::parsed::{Argument, Enum, Expr, Function, Identifier, LambdaSet, Program, Type};
+use ir::parsed::{Enum, Expr, Function, Identifier, LambdaSet, Program, Type};
 
 #[derive(Clone)]
 pub(crate) struct LambdaStruct {
@@ -61,7 +59,7 @@ impl Lower {
 
     fn tuple_name(&mut self, tuple: &[Type]) -> Identifier {
         if let Some(name) = self.tuples.get(tuple) {
-            return name.clone();
+            name.clone()
         } else {
             let name = self.fresh_name("tuple");
             self.tuples.insert(tuple.to_vec(), name.clone());
@@ -204,7 +202,7 @@ pub(crate) fn lower_program(to_lower: &Program, lower: &mut Lower) -> base::Prog
         functions.push(lower_function(func, lower));
     }
 
-    for (_, enum_def) in &to_lower.enums {
+    for enum_def in to_lower.enums.values() {
         enums.push(lower_enum(enum_def, lower));
     }
 
@@ -299,7 +297,7 @@ fn lower_expr(to_lower: &Expr, stmts: &mut Vec<Stmt>, lower: &mut Lower) -> Iden
             set,
             arguments,
         } => {
-            let lowered_func = lower_expr(&function, stmts, lower);
+            let lowered_func = lower_expr(function, stmts, lower);
             let lowered_args: Vec<_> = arguments
                 .iter()
                 .map(|arg| lower_expr(arg, stmts, lower))

--- a/lambda-set/src/unify.rs
+++ b/lambda-set/src/unify.rs
@@ -17,7 +17,7 @@ fn union_type(ty1: &Type, ty2: &Type, uf: &mut UnionFind) {
                 union_type(arg1, arg2, uf);
             }
 
-            union_type(&res1, &res2, uf);
+            union_type(res1, res2, uf);
         }
         (Tuple(elems1), Tuple(elems2)) => {
             assert_eq!(elems1.len(), elems2.len());
@@ -52,7 +52,7 @@ fn infer_expr(
     match to_infer {
         Expr::Integer(_) => Type::Integer,
         Expr::Variable { name, typ, .. } => {
-            let env_typ = env[&name].clone();
+            let env_typ = env[name].clone();
             if let Some(old_typ) = typ {
                 union_type(old_typ, &env_typ, uf);
             } else {
@@ -96,7 +96,7 @@ fn infer_expr(
                 inner.insert(arg.name.clone(), arg.typ.clone());
             }
             let inferred_result = infer_expr(body.as_mut(), inner, uf, enums);
-            union_type(&result, &inferred_result, uf);
+            union_type(result, &inferred_result, uf);
 
             let arg_types = arguments.iter().map(|arg| arg.typ.clone()).collect();
 

--- a/lambda-set/src/union_find.rs
+++ b/lambda-set/src/union_find.rs
@@ -19,11 +19,11 @@ impl UnionFind {
 
     pub fn root(&mut self, token: usize) -> usize {
         if self.elems[token] == token {
-            return token;
+            token
         } else {
             let root = self.root(self.elems[token]);
             self.elems[token] = root;
-            return root;
+            root
         }
     }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -7,7 +7,7 @@ use chumsky::{
     prelude::Simple,
     primitive::{end, filter, just},
     recursive::{self, Recursive},
-    text::{ident, int, keyword, whitespace},
+    text::{int, keyword, whitespace},
     Parser,
 };
 use ir::parsed::*;
@@ -59,8 +59,8 @@ fn comma_list<T>(element: parser!(T)) -> parser!(Vec<T>) {
 fn typ() -> parser!(Type) {
     recursive::recursive(|typ| {
         let int = keyword("Int").map(|_| Type::Integer);
-        let var = identifier().map(|name| Type::Variable(name));
-        let cons = upper_identifier().map(|name| Type::Constructor(name));
+        let var = identifier().map(Type::Variable);
+        let cons = upper_identifier().map(Type::Constructor);
         let func = just('(')
             .ignore_then(comma_list(typ.clone()))
             .then_ignore(just(')'))
@@ -74,7 +74,7 @@ fn typ() -> parser!(Type) {
             .ignore_then(comma_list(typ.clone()))
             .then_ignore(just('|'))
             .then_ignore(just('>'))
-            .map(|elems| Type::Tuple(elems));
+            .map(Type::Tuple);
         pad(func.or(int).or(var).or(tuple).or(cons))
     })
 }
@@ -140,7 +140,7 @@ fn expr() -> parser!(Expr) {
         .ignore_then(comma_list(expr.clone()))
         .then_ignore(just('|'))
         .then_ignore(just('>'))
-        .map(|elems| Expr::Tuple(elems));
+        .map(Expr::Tuple);
     let variant = upper_identifier()
         .then_ignore(just(':'))
         .then_ignore(just(':'))
@@ -182,7 +182,7 @@ fn expr() -> parser!(Expr) {
         .ignore_then(comma_list(expr.clone()))
         .then_ignore(just(')')));
 
-    let addon = access.map(|field| Ok(field)).or(call.map(|args| Err(args)));
+    let addon = access.map(Ok).or(call.map(Err));
     let trivial = pad(integer
         .or(match_)
         .or(variant)


### PR DESCRIPTION
Use the existing `codegen/generator` builder structs to convert `base` ir into `c` code.