### PR TITLE
Fix issue #12 Incorrect Unification

### DIFF
--- a/core/main.rs
+++ b/core/main.rs
@@ -4,10 +4,8 @@ use chumsky::error::Simple;
 use codegen::gen_program;
 use parser::parse_program;
 
-use std::{
-    fs,
-    io::{self, BufRead},
-};
+use std::fs;
+use std::io::{self, BufRead};
 
 fn main() {
     let stdin = io::stdin();

--- a/lambda-set/src/lib.rs
+++ b/lambda-set/src/lib.rs
@@ -2,7 +2,7 @@ use im::HashMap;
 use ir::{base, parsed::Program};
 use lower::{lower_program, Lower};
 use patch::{patch_function, Lambda, Patcher};
-use unify::infer_function;
+use unify::{infer_function, update_type};
 use union_find::UnionFind;
 
 mod lower;
@@ -17,7 +17,9 @@ pub fn program(prog: &mut Program) -> base::Program {
     let mut uf = UnionFind::new();
 
     for func in prog.functions.iter() {
-        env.insert(func.name.clone(), func.typ(uf.token()));
+        let mut typ = func.typ(uf.token());
+        update_type(&mut typ, &mut uf);
+        env.insert(func.name.clone(), typ);
     }
 
     for func in prog.functions.iter_mut() {

--- a/lambda-set/src/union_find.rs
+++ b/lambda-set/src/union_find.rs
@@ -5,7 +5,7 @@ pub struct UnionFind {
 
 impl UnionFind {
     pub fn new() -> Self {
-        Self { elems: Vec::new() }
+        Self { elems: vec![0] }
     }
 
     pub fn token(&mut self) -> usize {
@@ -15,12 +15,18 @@ impl UnionFind {
     }
 
     pub fn merge(&mut self, first: usize, second: usize) {
+        if first == 0 || second == 0 {
+            panic!("unifying {first} and {second}");
+        }
         println!("merging sets {first} and {second}");
         let first_root = self.root(first);
         self.elems[first_root] = self.root(second);
     }
 
     pub fn root(&mut self, token: usize) -> usize {
+        if token == 0 {
+            panic!("getting root of 0");
+        }
         if self.elems[token] == token {
             token
         } else {


### PR DESCRIPTION
Correctly assign new unification tokens to lambda sets in deeply nested function types, and stop reassigning new unification tokens to the env on each call to `infer_function`.