### PR TITLE
Fix #15 Incorrect Lowering with Multiple Lambdas

### DIFF
--- a/lambda-set/src/lib.rs
+++ b/lambda-set/src/lib.rs
@@ -2,7 +2,7 @@ use im::HashMap;
 use ir::{base, parsed::Program};
 use lower::{lower_program, Lower};
 use patch::{patch_function, Lambda, Patcher};
-use unify::{infer_function, update_type};
+use unify::{infer_function, update_type, Names};
 use union_find::UnionFind;
 
 mod lower;
@@ -22,8 +22,9 @@ pub fn program(prog: &mut Program) -> base::Program {
         env.insert(func.name.clone(), typ);
     }
 
+    let mut names = Names::default();
     for func in prog.functions.iter_mut() {
-        infer_function(func, env.clone(), &mut uf, &mut prog.enums);
+        infer_function(func, env.clone(), &mut uf, &mut prog.enums, &mut names);
     }
 
     let functions = prog

--- a/lambda-set/src/unify.rs
+++ b/lambda-set/src/unify.rs
@@ -56,14 +56,14 @@ pub(crate) fn infer_function(
     mut env: HashMap<Identifier, Type>,
     uf: &mut UnionFind,
     enums: &mut collections::HashMap<Identifier, Enum>,
+    names: &mut Names,
 ) {
-    let mut names = Names::default();
     for mut arg in to_infer.arguments.iter().cloned() {
         update_type(&mut arg.typ, uf);
         env.insert(arg.name, arg.typ);
     }
     update_type(&mut to_infer.result, uf);
-    let body_typ = infer_expr(&mut to_infer.body, env.clone(), uf, enums, &mut names);
+    let body_typ = infer_expr(&mut to_infer.body, env.clone(), uf, enums, names);
 
     union_type(&body_typ, &to_infer.result, uf);
 
@@ -75,7 +75,7 @@ pub(crate) fn infer_function(
 }
 
 #[derive(Default)]
-struct Names {
+pub(crate) struct Names {
     next: usize,
 }
 


### PR DESCRIPTION
Closures being returned in different functions were generated using overlapping names, as the source of fresh closure names was reset at the start of each function.