### PR TITLE
Fix #10 Incorrect Codegen with Differently Named Lambda Arguments

### DIFF
--- a/core/main.rs
+++ b/core/main.rs
@@ -247,4 +247,21 @@ mod test {
             14
         );
     }
+
+    #[test]
+    fn different_named_arguments() {
+        test_program!(
+            r#"
+                enum Bool {
+                    true(<||>),
+                    false(<||>)
+                }
+                fn main() -> Int = (match Bool::true(<||>) {
+                    true(x) => [](a: Int) -> Int = a,
+                    false(x) => [](b: Int) -> Int = b
+                })(15)
+            "#,
+            15
+        )
+    }
 }

--- a/core/main.rs
+++ b/core/main.rs
@@ -6,7 +6,6 @@ use parser::parse_program;
 
 use std::fs;
 use std::io::{self, BufRead};
-
 fn main() {
     let stdin = io::stdin();
     let mut text = String::new();

--- a/lambda-set/src/lower.rs
+++ b/lambda-set/src/lower.rs
@@ -150,6 +150,7 @@ pub(crate) fn lower_program(to_lower: &Program, lower: &mut Lower) -> base::Prog
                     typ: lower_type(&arg.typ, lower),
                 })
                 .collect();
+            let case_call_args = arguments.clone();
             arguments.push(func_name.clone());
             let mut body = BlockBuilder::default();
             let result_typ = lower_type(&lambda_struct.lambdas[0].result, lower);
@@ -171,11 +172,7 @@ pub(crate) fn lower_program(to_lower: &Program, lower: &mut Lower) -> base::Prog
                     );
                     let payload_var = lower.fresh_var(payload_typ);
 
-                    let mut call_args: Vec<_> = lambda
-                        .arguments
-                        .iter()
-                        .map(|arg| Variable::new(arg.name.clone(), lower_type(&arg.typ, lower)))
-                        .collect();
+                    let mut call_args = case_call_args.clone();
 
                     for (i, cap) in lambda.captures.iter().enumerate() {
                         let var_typ = lower_type(&cap.typ, lower);


### PR DESCRIPTION
The generated `call_closure_x` series of functions were incorrectly assuming that the arguments to the functions were named following the names of the arguments in each lambda in the lambda set, when it reality they are based off of the first lambda.