### PR TITLE
Fix #18 Incorrect Unification of Lambda Sets in Enum Variants

### DIFF
--- a/core/main.rs
+++ b/core/main.rs
@@ -6,6 +6,8 @@ use parser::parse_program;
 
 use std::fs;
 use std::io::{self, BufRead};
+
+/*
 fn main() {
     let stdin = io::stdin();
     let mut text = String::new();
@@ -36,6 +38,35 @@ fn main() {
         text.push_str(&line);
         text.push('\n');
     }
+}
+*/
+fn main() {
+    let text = r#"
+        enum Thunk {
+            f(() -> Int)
+        }
+        fn main() -> Int = match <|Thunk::f([]() -> Int = 3), Thunk::f([]() -> Int = 4)|>.0 {
+            f(x) => x()
+        }
+    "#;
+    let parsed = match parse_program(&text) {
+        Ok(p) => p,
+        Err(errors) => {
+            for error in errors {
+                parse_error(&text, error);
+            }
+            return;
+        }
+    };
+    let mut flat = flatten::program(parsed);
+    let base = lambda_set::program(&mut flat);
+    println!("{:?}", base);
+
+    let c = gen_program(&base).generate();
+
+    //println!("{}", c);
+
+    fs::write("./target/test.c", c).unwrap();
 }
 
 fn parse_error(text: &str, error: Simple<char>) {

--- a/core/main.rs
+++ b/core/main.rs
@@ -7,7 +7,6 @@ use parser::parse_program;
 use std::fs;
 use std::io::{self, BufRead};
 
-/*
 fn main() {
     let stdin = io::stdin();
     let mut text = String::new();
@@ -38,35 +37,6 @@ fn main() {
         text.push_str(&line);
         text.push('\n');
     }
-}
-*/
-fn main() {
-    let text = r#"
-        enum Thunk {
-            f(() -> Int)
-        }
-        fn main() -> Int = match <|Thunk::f([]() -> Int = 3), Thunk::f([]() -> Int = 4)|>.0 {
-            f(x) => x()
-        }
-    "#;
-    let parsed = match parse_program(&text) {
-        Ok(p) => p,
-        Err(errors) => {
-            for error in errors {
-                parse_error(&text, error);
-            }
-            return;
-        }
-    };
-    let mut flat = flatten::program(parsed);
-    let base = lambda_set::program(&mut flat);
-    println!("{:?}", base);
-
-    let c = gen_program(&base).generate();
-
-    //println!("{}", c);
-
-    fs::write("./target/test.c", c).unwrap();
 }
 
 fn parse_error(text: &str, error: Simple<char>) {
@@ -293,6 +263,21 @@ mod test {
                 })(15)
             "#,
             15
+        )
+    }
+
+    #[test]
+    fn lambdas_in_enums() {
+        test_program!(
+            r#"
+                enum Thunk {
+                    f(() -> Int)
+                }
+                fn main() -> Int = match <|Thunk::f([]() -> Int = 16), Thunk::f([]() -> Int = 17)|>.0 {
+                    f(x) => x()
+                }       
+            "#,
+            16
         )
     }
 }

--- a/lambda-set/src/lower.rs
+++ b/lambda-set/src/lower.rs
@@ -108,14 +108,7 @@ pub(crate) fn lower_program(to_lower: &Program, lower: &mut Lower) -> base::Prog
     let mut functions = Vec::new();
     let mut enums = Vec::new();
 
-    println!("lowering program with start");
-    for func in &to_lower.functions {
-        println!("{:?}", func);
-    }
-
     let pools: Vec<_> = lower.pools.iter().map(|(k, v)| (*k, v.clone())).collect();
-    println!("{:?}", pools);
-    println!("lowering program with end");
     for (token, lambda_struct) in pools {
         let cases = lambda_struct
             .lambdas


### PR DESCRIPTION
Enum variant types were previously not being unified, resulting in variants containing function types having unresolved lambda sets.